### PR TITLE
Add storybook ghpages deploy workflow

### DIFF
--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -1,0 +1,52 @@
+name: Pages Deploy
+on:
+  workflow_dispatch:
+    inputs:
+      distinct_id:
+        description: "Distinct ID used by the caller to find this workflow"
+        required: false
+      run-id:
+        description: "Caller Run ID used to find the artifact to deploy"
+        required: true
+        type: string
+      artifact-name:
+        description: "Name of the artifact to download"
+        required: true
+        type: string
+
+jobs:
+  # Deploy job
+  deploy:
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      # Distinct ID used by the caller to find this workflow
+      - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
+        run: echo ${{ github.event.inputs.distinct_id }}
+      # Download artifact from a different repository
+      - name: Download artifact
+        id: download-artifact
+        uses: actions/download-artifact@v4
+        with:
+          repository: govbydesign/almd
+          run-id: ${{ inputs.run-id }}
+          github-token: ${{ secrets.GH_REPO_SCOPE_TOKEN }}
+          name: ${{ inputs.artifact-name }}
+      # Required as deploy to pages doesn't allow an artifact from a different repository
+      - name: "Upload Artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-pages
+          path: artifact.tar
+          retention-days: 1
+      # Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### What does this PR do?

This PR adds a custom github workflow that can only be triggered via `workflow_dispatch`. This will be invoked by another repository to finish deployment of assets.